### PR TITLE
構造体使用時のstructキーワード及び宣言時のtypedefの削除

### DIFF
--- a/raspi/include/GY521.hpp
+++ b/raspi/include/GY521.hpp
@@ -39,7 +39,7 @@ public:
     yaw_ = start;
   }
   double checkStatus();
-  struct GY521Param checkParam();
+  GY521Param checkParam();
 
 private:
   I2c i2c_;
@@ -49,7 +49,7 @@ private:
   }
   double gyro_z_now_ = 0;
   double gyro_z_prev_ = 0;
-  struct timespec now_, prev_;
-  struct GY521Param param_;
+  timespec now_, prev_;
+  GY521Param param_;
 };
 };

--- a/raspi/include/motor_serial.hpp
+++ b/raspi/include/motor_serial.hpp
@@ -11,11 +11,11 @@ using ros::Pigpiod;
 using ros::Serial;
 
 namespace ros {
-typedef struct {
+struct SendDataFormat{
   unsigned char id;
   unsigned char cmd;
   short argData;
-} SendDataFormat;
+};
 
 class MotorSerial {
 public:

--- a/raspi/src/GY521.cpp
+++ b/raspi/src/GY521.cpp
@@ -79,6 +79,6 @@ void GY521::update() {
   }
 }
 
-struct ros::GY521Param GY521::checkParam() {
+ros::GY521Param GY521::checkParam() {
   return param_;
 }


### PR DESCRIPTION
structとclassにはデフォルトのアクセスレベル以外にはほぼ違いがなく、structを使用するにあたって上のようなコードは不要だと思われる