### PR TITLE
[MotorSerial::send] passing arguments by const reference

### DIFF
--- a/raspi/include/motor_serial.hpp
+++ b/raspi/include/motor_serial.hpp
@@ -26,7 +26,7 @@ public:
   short sending(unsigned char id, unsigned char cmd, short data);
   short send(unsigned char id, unsigned char cmd, short data,
              bool async_flag = false);
-  short send(SendDataFormat send_data, bool async_flag);
+  short send(const SendDataFormat &send_data, bool async_flag);
   virtual ~MotorSerial();
   bool sum_check_success_;
   short recent_receive_data_;

--- a/raspi/src/motor_serial.cpp
+++ b/raspi/src/motor_serial.cpp
@@ -126,7 +126,7 @@ short MotorSerial::send(unsigned char id, unsigned char cmd, short data,
   return sending(id, cmd, data);
 }
 
-short MotorSerial::send(SendDataFormat send_data, bool async_flag) {
+short MotorSerial::send(const SendDataFormat &send_data, bool async_flag) {
   return send(send_data.id, send_data.cmd, send_data.argData, async_flag);
 }
 


### PR DESCRIPTION
一般的にclassのコピーは時間がかかるが, 参照で渡すと誤って参照元を変更してしまうかもしれない.
 -> const参照で渡す